### PR TITLE
change domain var to include protocol and port

### DIFF
--- a/part-1-set-up-shop/index.html
+++ b/part-1-set-up-shop/index.html
@@ -97,7 +97,7 @@
       var order = { id: "sku_FsWm2bRjTafCXX" };
       // Replace with your Stripe publishable key
       var stripe = Stripe("pk_test_12345");
-      var domain = window.location.hostname;
+      var domain = window.location.origin;
 
       document
         .getElementById("pay-button")


### PR DESCRIPTION
Error when running locally: successUrl must start with either http:// or https://
This also will allow a redirect from Stripe checkout to the completed.html page by including the port.  

window.location.hostname // 127.0.0.1
window.location.origin // http://127.0.0.1:5500